### PR TITLE
Feature: Finalize monthly autofill weekly zap

### DIFF
--- a/src/features/meetings/monthly_view/add_custom_modal_window/index.tsx
+++ b/src/features/meetings/monthly_view/add_custom_modal_window/index.tsx
@@ -7,9 +7,12 @@ import Button from '@components/button';
 import PartDuration from '@features/meetings/part_duration';
 import MeetingPart from '@features/meetings/meeting_part';
 import useAddCustomModalWindow from './useAddCustomModalWindow';
+import { useAtomValue } from 'jotai';
+import { userDataViewState } from '@states/settings';
 
 const AddCustomModalWindow = (props: AddCustomModalWindowType) => {
   const { t } = useAppTranslation();
+  const dataView = useAtomValue(userDataViewState);
 
   const { handleDeleteCustomLCPart, week, handleAddCustomLCPart } =
     useAddCustomModalWindow(props);
@@ -56,6 +59,7 @@ const AddCustomModalWindow = (props: AddCustomModalWindowType) => {
           color="var(--living-as-christians)"
           isEdit={true}
           isOverwrite={true}
+          dataView={dataView}
         />
       </Box>
       <Box

--- a/src/features/meetings/monthly_view/index.tsx
+++ b/src/features/meetings/monthly_view/index.tsx
@@ -79,6 +79,11 @@ const MonthlyView = () => {
           border: '1px solid var(--accent-300)',
           borderRadius: 'var(--radius-xl)',
           backgroundColor: 'var(--white)',
+          // Force the floating label to always appear in the shrunk position so
+          // that empty columns match the visual height of filled columns.
+          '& .MuiFormLabel-root[data-shrink=false]': {
+            transform: 'translate(14px, -9px) scale(0.75)',
+          },
         }}
       >
         {/* --------------------------- MonhlyView Header -------------------------- */}

--- a/src/features/meetings/monthly_view/index.tsx
+++ b/src/features/meetings/monthly_view/index.tsx
@@ -81,6 +81,13 @@ const MonthlyView = () => {
           border: '1px solid var(--accent-300)',
           borderRadius: 'var(--radius-xl)',
           backgroundColor: 'var(--white)',
+          // Constrain helper/warning text to the column width without clipping
+          // the floating label (which is inside the input bounds, not a helper).
+          '& .MuiFormHelperText-root': {
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          },
         }}
       >
         {/* --------------------------- MonhlyView Header -------------------------- */}
@@ -139,7 +146,7 @@ const MonthlyView = () => {
                 key={`main-hall-chairman-${index}`}
                 week={value}
                 showIcon={false}
-                flex={false}
+                flex={true}
                 label={t('tr_chairman')}
                 type={AssignmentCode.MM_Chairman}
                 assignment="MM_Chairman_A"
@@ -167,7 +174,7 @@ const MonthlyView = () => {
                     key={`aux-classroom-counselor-${index}`}
                     week={value}
                     showIcon={false}
-                    flex={false}
+                    flex={true}
                     label={t('tr_chairman')}
                     type={AssignmentCode.MM_AuxiliaryCounselor}
                     assignment="MM_Chairman_B"
@@ -198,7 +205,7 @@ const MonthlyView = () => {
                 key={`opening-prayer-${index}`}
                 week={value}
                 showIcon={false}
-                flex={false}
+                flex={true}
                 label={t('tr_prayer')}
                 type={AssignmentCode.MM_Prayer}
                 assignment={
@@ -1092,7 +1099,7 @@ const MonthlyView = () => {
                   key={`closing-prayer-${index}`}
                   week={value}
                   showIcon={false}
-                  flex={false}
+                  flex={true}
                   label={t('tr_prayer')}
                   type={AssignmentCode.MM_Prayer}
                   assignment={

--- a/src/features/meetings/monthly_view/index.tsx
+++ b/src/features/meetings/monthly_view/index.tsx
@@ -108,6 +108,7 @@ const MonthlyView = () => {
             return (
               <WeekBadge
                 key={index}
+                week={value}
                 text={getWeekLocale(
                   new Date(value).getDate(),
                   thisYearMonths[selectedMonth]

--- a/src/features/meetings/monthly_view/index.tsx
+++ b/src/features/meetings/monthly_view/index.tsx
@@ -63,6 +63,7 @@ const MonthlyView = () => {
     handleAddCustomLCPart,
     openingPrayerLinked,
     closingPrayerLinked,
+    isWeekAvailable,
   } = useMonthlyView();
 
   const { t } = useAppTranslation();
@@ -109,6 +110,7 @@ const MonthlyView = () => {
               <WeekBadge
                 key={index}
                 week={value}
+                isWeekAvailable={isWeekAvailable(value)}
                 text={getWeekLocale(
                   new Date(value).getDate(),
                   thisYearMonths[selectedMonth]

--- a/src/features/meetings/monthly_view/index.tsx
+++ b/src/features/meetings/monthly_view/index.tsx
@@ -1,4 +1,5 @@
 import { Box } from '@mui/material';
+import { addDays } from '@utils/date';
 import useAppTranslation from '@hooks/useAppTranslation';
 import { Button, MenuItem, Select, Typography } from '@components/index';
 import WeekBadge from './week_badge';
@@ -64,6 +65,7 @@ const MonthlyView = () => {
     handleAddCustomLCPart,
     openingPrayerLinked,
     closingPrayerLinked,
+    meetingWeekday,
   } = useMonthlyView();
 
   const { t } = useAppTranslation();
@@ -79,11 +81,6 @@ const MonthlyView = () => {
           border: '1px solid var(--accent-300)',
           borderRadius: 'var(--radius-xl)',
           backgroundColor: 'var(--white)',
-          // Force the floating label to always appear in the shrunk position so
-          // that empty columns match the visual height of filled columns.
-          '& .MuiFormLabel-root[data-shrink=false]': {
-            transform: 'translate(14px, -9px) scale(0.75)',
-          },
         }}
       >
         {/* --------------------------- MonhlyView Header -------------------------- */}
@@ -112,13 +109,14 @@ const MonthlyView = () => {
             })}
           </Select>
           {selectedWeeks.map((value, index) => {
+            const meetingDate = addDays(value, meetingWeekday);
             return (
               <WeekBadge
                 key={index}
                 week={value}
                 text={getWeekLocale(
-                  new Date(value).getDate(),
-                  thisYearMonths[selectedMonth]
+                  meetingDate.getDate(),
+                  thisYearMonths[meetingDate.getMonth()]
                 )}
               />
             );

--- a/src/features/meetings/monthly_view/index.tsx
+++ b/src/features/meetings/monthly_view/index.tsx
@@ -30,6 +30,7 @@ const MonthlyView = () => {
     currentYear,
     selectedMonth,
     thisYearMonths,
+    availableMonthIndices,
     setSelectedMonth,
     classCount,
     showDoublePerson,
@@ -97,6 +98,7 @@ const MonthlyView = () => {
             }
           >
             {thisYearMonths?.map((value, index) => {
+              if (!availableMonthIndices.has(index)) return null;
               return (
                 <MenuItem value={index} key={index}>
                   {`${value} ${currentYear}`}

--- a/src/features/meetings/monthly_view/index.tsx
+++ b/src/features/meetings/monthly_view/index.tsx
@@ -63,7 +63,6 @@ const MonthlyView = () => {
     handleAddCustomLCPart,
     openingPrayerLinked,
     closingPrayerLinked,
-    isWeekAvailable,
   } = useMonthlyView();
 
   const { t } = useAppTranslation();
@@ -110,7 +109,6 @@ const MonthlyView = () => {
               <WeekBadge
                 key={index}
                 week={value}
-                isWeekAvailable={isWeekAvailable(value)}
                 text={getWeekLocale(
                   new Date(value).getDate(),
                   thisYearMonths[selectedMonth]

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -443,6 +443,7 @@ const useMonthlyView = () => {
     openingPrayerLinked,
     closingPrayerLinked,
     showDoublePerson,
+    meetingWeekday,
 
     // Selected Month & Week Information
     monthName,

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -111,24 +111,17 @@ const useMonthlyView = () => {
   const [addCustomModalWindowWeek, setAddCustomModalWindowWeek] =
     useState(null);
 
-  // Derive the last month for which source data is available from JW.ORG.
-  // Any month beyond this will be hidden from the month selector.
-  const lastAvailableMonth = useMemo(() => {
-    if (sources.length === 0) return new Date().getMonth();
-    const lastWeekOf = sources.reduce(
-      (max, s) => (s.weekOf > max ? s.weekOf : max),
-      sources[0].weekOf
-    );
-    return new Date(lastWeekOf).getMonth();
+  // Derive which month indices (0-11) have at least one available week.
+  // Used to hide months with no source data from the dropdown.
+  const availableMonthIndices = useMemo(() => {
+    const set = new Set<number>();
+    sources.forEach((s) => set.add(new Date(s.weekOf).getMonth()));
+    return set;
   }, [sources]);
 
-  const thisYearMonths = useMemo(
-    () => monthNames.slice(0, lastAvailableMonth + 1),
-    [monthNames, lastAvailableMonth]
-  );
+  const thisYearMonths = monthNames;
 
   const monthName = thisYearMonths[selectedMonth];
-
 
   const getWeekLocale = (date, monthName) => {
     return t('tr_longDateNoYearLocale', {
@@ -201,19 +194,24 @@ const useMonthlyView = () => {
     });
   };
 
-  // Clamp selectedMonth if it's now beyond the last available month
-  // (can happen when source data resets or the user had a future month open).
+  // Clamp selectedMonth to an available month when the selection has no data.
+  // Jumps to the highest available month index.
   useEffect(() => {
-    if (selectedMonth > lastAvailableMonth) {
-      setSelectedMonth(lastAvailableMonth);
+    if (availableMonthIndices.size > 0 && !availableMonthIndices.has(selectedMonth)) {
+      const lastAvailable = Math.max(...Array.from(availableMonthIndices));
+      setSelectedMonth(lastAvailable);
     }
-  }, [lastAvailableMonth, selectedMonth]);
+  }, [availableMonthIndices, selectedMonth]);
 
   useEffect(() => {
-    setSelectedWeeks(
-      getWeeksByMonthAndYear(parseInt(currentYear), selectedMonth)
+    // Only show weeks that have source data — mirrors weekly view behaviour.
+    const allWeeks = getWeeksByMonthAndYear(parseInt(currentYear), selectedMonth);
+    const availableWeeks = allWeeks.filter((week) =>
+      sources.some((s) => s.weekOf === week)
     );
-  }, [currentYear, getWeeksByMonthAndYear, selectedMonth]);
+    setSelectedWeeks(availableWeeks);
+  }, [currentYear, getWeeksByMonthAndYear, selectedMonth, sources]);
+
 
 
   // Reset all parallel state arrays when the selected month changes and
@@ -418,6 +416,7 @@ const useMonthlyView = () => {
     // General Settings
     currentYear,
     thisYearMonths,
+    availableMonthIndices,
     openingPrayerLinked,
     closingPrayerLinked,
     showDoublePerson,

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -118,10 +118,11 @@ const useMonthlyView = () => {
   const [addCustomModalWindowWeek, setAddCustomModalWindowWeek] =
     useState(null);
 
-  const thisYearMonths = sourcesFormatted
-    .find((year) => year.value.toString() === currentYear)
-    .months.toReversed()
-    .map((month) => monthNames[month.value]);
+  const thisYearMonths =
+    sourcesFormatted
+      .find((year) => year.value.toString() === currentYear)
+      ?.months.toReversed()
+      .map((month) => monthNames[month.value]) || [];
 
   const monthName = thisYearMonths[selectedMonth];
 

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -208,13 +208,18 @@ const useMonthlyView = () => {
   }, [availableMonthIndices, selectedMonth]);
 
   useEffect(() => {
-    // Only show weeks that have source data — mirrors weekly view behaviour.
-    const allWeeks = getWeeksByMonthAndYear(parseInt(currentYear), selectedMonth);
-    const availableWeeks = allWeeks.filter((week) =>
-      sources.some((s) => s.weekOf === week)
-    );
-    setSelectedWeeks(availableWeeks);
-  }, [currentYear, getWeeksByMonthAndYear, selectedMonth, sources]);
+    // Use the actual weekOf values from sourcesState for this month.
+    // JW.org weeks may not start on Mondays, so matching against
+    // weeksInMonth() (which generates Mondays) would fail to find them.
+    const monthWeeks = sources
+      .filter((s) => {
+        if (!s.weekOf.startsWith(currentYear)) return false;
+        return new Date(s.weekOf).getMonth() === selectedMonth;
+      })
+      .map((s) => s.weekOf)
+      .sort();
+    setSelectedWeeks(monthWeeks);
+  }, [currentYear, selectedMonth, sources]);
 
 
 

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -39,10 +39,11 @@ const useMonthlyView = () => {
   const getWeeksByMonthAndYear = useCallback(
     (year: number, month: number) => {
       let weeks = [];
+      const monthStr = `${year}/${String(month + 1).padStart(2, '0')}`;
       sourcesFormatted.forEach((srcYear) => {
         if (srcYear.value == year) {
           weeks = srcYear.months.find(
-            (formattedMonth) => formattedMonth.value == month
+            (formattedMonth) => formattedMonth.value === monthStr
           )?.weeks || [];
         }
       });
@@ -118,11 +119,7 @@ const useMonthlyView = () => {
   const [addCustomModalWindowWeek, setAddCustomModalWindowWeek] =
     useState(null);
 
-  const thisYearMonths =
-    sourcesFormatted
-      .find((year) => year.value.toString() === currentYear)
-      ?.months.toReversed()
-      .map((month) => monthNames[month.value]) || [];
+  const thisYearMonths = monthNames;
 
   const monthName = thisYearMonths[selectedMonth];
 

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -422,10 +422,6 @@ const useMonthlyView = () => {
     closingPrayerLinked,
     showDoublePerson,
 
-    // Availability helper used by WeekBadge to guard autofill
-    isWeekAvailable: (weekOf: string) =>
-      sources.some((s) => s.weekOf === weekOf),
-
     // Selected Month & Week Information
     monthName,
     selectedMonth,

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -111,17 +111,20 @@ const useMonthlyView = () => {
   const [addCustomModalWindowWeek, setAddCustomModalWindowWeek] =
     useState(null);
 
-  // Derive which month indices (0-11) have at least one available week
-  // in the CURRENT year. Used to hide months with no source data from the dropdown.
+  // Derive which month indices (0-11) have published material for the current year.
+  // Uses the same filter as the weekly view: week_date_locale[lang] must have content.
   const availableMonthIndices = useMemo(() => {
     const set = new Set<number>();
     sources.forEach((s) => {
-      if (s.weekOf.startsWith(currentYear)) {
+      if (
+        s.weekOf.startsWith(currentYear) &&
+        s.midweek_meeting?.week_date_locale?.[lang]?.length > 0
+      ) {
         set.add(new Date(s.weekOf).getMonth());
       }
     });
     return set;
-  }, [sources, currentYear]);
+  }, [sources, currentYear, lang]);
 
   const thisYearMonths = monthNames;
 
@@ -208,18 +211,20 @@ const useMonthlyView = () => {
   }, [availableMonthIndices, selectedMonth]);
 
   useEffect(() => {
-    // Use the actual weekOf values from sourcesState for this month.
-    // JW.org weeks may not start on Mondays, so matching against
-    // weeksInMonth() (which generates Mondays) would fail to find them.
+    // Use the SAME filter as the weekly view (useMidweekContainer):
+    // a week is only shown if week_date_locale[lang] has content,
+    // meaning JW.org has published the meeting programme for that week.
     const monthWeeks = sources
-      .filter((s) => {
-        if (!s.weekOf.startsWith(currentYear)) return false;
-        return new Date(s.weekOf).getMonth() === selectedMonth;
-      })
+      .filter(
+        (s) =>
+          s.weekOf.startsWith(currentYear) &&
+          new Date(s.weekOf).getMonth() === selectedMonth &&
+          s.midweek_meeting?.week_date_locale?.[lang]?.length > 0
+      )
       .map((s) => s.weekOf)
       .sort();
     setSelectedWeeks(monthWeeks);
-  }, [currentYear, selectedMonth, sources]);
+  }, [currentYear, selectedMonth, sources, lang]);
 
 
 

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -16,7 +16,7 @@ import {
   midweekMeetingOpeningPrayerLinkedState,
   userDataViewState,
 } from '@states/settings';
-import { sourcesFormattedState, sourcesState } from '@states/sources';
+import { sourcesState } from '@states/sources';
 import { SetStateAction, useCallback, useEffect, useState } from 'react';
 import { useAtomValue } from 'jotai';
 
@@ -24,7 +24,6 @@ const useMonthlyView = () => {
   const { t } = useAppTranslation();
 
   const monthNames = useAtomValue(monthNamesState);
-  const sourcesFormatted = useAtomValue(sourcesFormattedState);
   const sources = useAtomValue(sourcesState);
   const schedules = useAtomValue(schedulesState);
   const dataView = useAtomValue(userDataViewState);

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -1,6 +1,6 @@
 import { AssignmentCode } from '@definition/assignment';
 import { Week } from '@definition/week_type';
-import { weeksInMonth } from '@utils/date';
+import { weeksInMonth, addDays } from '@utils/date';
 import useAppTranslation from '@hooks/useAppTranslation';
 import {
   sourcesCheckAYFExplainBeliefsAssignment,
@@ -14,6 +14,7 @@ import {
   midweekMeetingClassCountState,
   midweekMeetingClosingPrayerLinkedState,
   midweekMeetingOpeningPrayerLinkedState,
+  midweekMeetingWeekdayState,
   userDataViewState,
 } from '@states/settings';
 import { sourcesState } from '@states/sources';
@@ -28,6 +29,7 @@ const useMonthlyView = () => {
   const schedules = useAtomValue(schedulesState);
   const dataView = useAtomValue(userDataViewState);
   const classCount = useAtomValue(midweekMeetingClassCountState);
+  const meetingWeekday = useAtomValue(midweekMeetingWeekdayState);
   const lang = useAtomValue(JWLangState);
   const openingPrayerLinked = useAtomValue(
     midweekMeetingOpeningPrayerLinkedState
@@ -112,7 +114,9 @@ const useMonthlyView = () => {
     useState(null);
 
   // Derive which month indices (0-11) have published material for the current year.
-  // Uses the same filter as the weekly view: week_date_locale[lang] must have content.
+  // IMPORTANT: uses the actual meeting date (weekOf + congregation weekday offset)
+  // so that e.g. weekOf=2026/08/31 with Thursday meeting correctly shows under
+  // September (meeting date = Sept 3), not August. Mirrors schedulesGetMeetingDate.
   const availableMonthIndices = useMemo(() => {
     const set = new Set<number>();
     sources.forEach((s) => {
@@ -120,11 +124,12 @@ const useMonthlyView = () => {
         s.weekOf.startsWith(currentYear) &&
         s.midweek_meeting?.week_date_locale?.[lang]?.length > 0
       ) {
-        set.add(new Date(s.weekOf).getMonth());
+        const meetingDate = addDays(s.weekOf, meetingWeekday);
+        set.add(meetingDate.getMonth());
       }
     });
     return set;
-  }, [sources, currentYear, lang]);
+  }, [sources, currentYear, lang, meetingWeekday]);
 
   const thisYearMonths = monthNames;
 
@@ -211,20 +216,24 @@ const useMonthlyView = () => {
   }, [availableMonthIndices, selectedMonth]);
 
   useEffect(() => {
-    // Use the SAME filter as the weekly view (useMidweekContainer):
-    // a week is only shown if week_date_locale[lang] has content,
-    // meaning JW.org has published the meeting programme for that week.
+    // Use the actual meeting date (weekOf + congregation weekday) to group weeks
+    // by month — identical to schedulesGetMeetingDate logic used in the weekly view.
+    // weekOf is always Monday; the real meeting date may fall in the next month
+    // (e.g. weekOf=2026/08/31 + Thursday=4 → Sept 3 → month index 8 = September).
     const monthWeeks = sources
-      .filter(
-        (s) =>
-          s.weekOf.startsWith(currentYear) &&
-          new Date(s.weekOf).getMonth() === selectedMonth &&
-          s.midweek_meeting?.week_date_locale?.[lang]?.length > 0
-      )
+      .filter((s) => {
+        if (!s.midweek_meeting?.week_date_locale?.[lang]?.length) return false;
+        const meetingDate = addDays(s.weekOf, meetingWeekday);
+        const meetingYear = meetingDate.getFullYear().toString();
+        return (
+          meetingYear === currentYear &&
+          meetingDate.getMonth() === selectedMonth
+        );
+      })
       .map((s) => s.weekOf)
       .sort();
     setSelectedWeeks(monthWeeks);
-  }, [currentYear, selectedMonth, sources, lang]);
+  }, [currentYear, selectedMonth, sources, lang, meetingWeekday]);
 
 
 

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -43,7 +43,7 @@ const useMonthlyView = () => {
         if (srcYear.value == year) {
           weeks = srcYear.months.find(
             (formattedMonth) => formattedMonth.value == month
-          ).weeks;
+          )?.weeks || [];
         }
       });
       return weeks;

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -225,19 +225,24 @@ const useMonthlyView = () => {
       changeValueInArrayState(
         setAyfCount,
         index,
-        source.midweek_meeting.ayf_count[lang]
+        source?.midweek_meeting?.ayf_count[lang] || 3
       );
 
       ayfPartsSetters.forEach((setter, setterIndex) => {
-        const ayfPart = source.midweek_meeting[`ayf_part${setterIndex + 1}`];
+        const ayfPart = source?.midweek_meeting[`ayf_part${setterIndex + 1}`];
 
-        changeValueInArrayState(setter, index, ayfPart.type[lang]);
+        let partType = ayfPart?.type[lang];
+        if (!partType || partType === 0) {
+          partType = AssignmentCode.MM_StartingConversation;
+        }
 
-        if (ayfPart.type[lang] === AssignmentCode.MM_ExplainingBeliefs) {
+        changeValueInArrayState(setter, index, partType);
+
+        if (partType === AssignmentCode.MM_ExplainingBeliefs) {
           changeValueInArrayState(
             isTalkAYFPartsSetters[setterIndex],
             index,
-            sourcesCheckAYFExplainBeliefsAssignment(ayfPart.src[lang], lang)
+            sourcesCheckAYFExplainBeliefsAssignment(ayfPart?.src[lang], lang)
           );
         }
       });

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -196,11 +196,11 @@ const useMonthlyView = () => {
     selectedWeeks.forEach((value, index) => {
       const schedule = schedules.find((record) => record.weekOf === value);
 
-      const weekType = schedule.midweek_meeting.week_type.find(
+      const weekType = schedule?.midweek_meeting?.week_type?.find(
         (record) => record.type === dataView
       );
 
-      changeValueInArrayState(setWeeksTypes, index, weekType);
+      changeValueInArrayState(setWeeksTypes, index, weekType || Week.NORMAL);
     });
   }, [selectedWeeks, schedules, dataView]);
 
@@ -261,11 +261,11 @@ const useMonthlyView = () => {
       const source = sources.find((record) => record.weekOf === value);
 
       const lcCountOverride =
-        source.midweek_meeting.lc_count.override.find(
+        source?.midweek_meeting?.lc_count?.override?.find(
           (record) => record.type === dataView
         )?.value || 0;
 
-      const lcCount = source.midweek_meeting.lc_count.default[lang];
+      const lcCount = source?.midweek_meeting?.lc_count?.default?.[lang] || 0;
 
       changeValueInArrayState(setLcCount, index, lcCount);
 
@@ -282,14 +282,14 @@ const useMonthlyView = () => {
       );
 
       lcNoAssignPartsSetters.forEach((setter, setterIndex) => {
-        const lcSrcPart = source.midweek_meeting[`lc_part${setterIndex + 1}`];
+        const lcSrcPart = source?.midweek_meeting?.[`lc_part${setterIndex + 1}`];
 
-        const lcSrcOverride = lcSrcPart.title.override.find(
+        const lcSrcOverride = lcSrcPart?.title?.override?.find(
           (record) => record.type === dataView
         )?.value;
 
         const lcSrcDefault =
-          source.midweek_meeting[`lc_part${setterIndex + 1}`].title.default[
+          source?.midweek_meeting?.[`lc_part${setterIndex + 1}`]?.title?.default?.[
           lang
           ];
 
@@ -310,7 +310,7 @@ const useMonthlyView = () => {
       });
 
       const lc3Src =
-        source.midweek_meeting.lc_part3.title.find(
+        source?.midweek_meeting?.lc_part3?.title?.find(
           (record) => record.type === dataView
         )?.value || '';
 

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -17,7 +17,7 @@ import {
   userDataViewState,
 } from '@states/settings';
 import { sourcesState } from '@states/sources';
-import { SetStateAction, useCallback, useEffect, useState } from 'react';
+import { SetStateAction, useCallback, useEffect, useMemo, useState } from 'react';
 import { useAtomValue } from 'jotai';
 
 const useMonthlyView = () => {
@@ -111,9 +111,24 @@ const useMonthlyView = () => {
   const [addCustomModalWindowWeek, setAddCustomModalWindowWeek] =
     useState(null);
 
-  const thisYearMonths = monthNames;
+  // Derive the last month for which source data is available from JW.ORG.
+  // Any month beyond this will be hidden from the month selector.
+  const lastAvailableMonth = useMemo(() => {
+    if (sources.length === 0) return new Date().getMonth();
+    const lastWeekOf = sources.reduce(
+      (max, s) => (s.weekOf > max ? s.weekOf : max),
+      sources[0].weekOf
+    );
+    return new Date(lastWeekOf).getMonth();
+  }, [sources]);
+
+  const thisYearMonths = useMemo(
+    () => monthNames.slice(0, lastAvailableMonth + 1),
+    [monthNames, lastAvailableMonth]
+  );
 
   const monthName = thisYearMonths[selectedMonth];
+
 
   const getWeekLocale = (date, monthName) => {
     return t('tr_longDateNoYearLocale', {
@@ -186,11 +201,20 @@ const useMonthlyView = () => {
     });
   };
 
+  // Clamp selectedMonth if it's now beyond the last available month
+  // (can happen when source data resets or the user had a future month open).
+  useEffect(() => {
+    if (selectedMonth > lastAvailableMonth) {
+      setSelectedMonth(lastAvailableMonth);
+    }
+  }, [lastAvailableMonth, selectedMonth]);
+
   useEffect(() => {
     setSelectedWeeks(
       getWeeksByMonthAndYear(parseInt(currentYear), selectedMonth)
     );
   }, [currentYear, getWeeksByMonthAndYear, selectedMonth]);
+
 
   // Reset all parallel state arrays when the selected month changes and
   // selectedWeeks grows or shrinks. Without this, out-of-bounds indices
@@ -397,6 +421,10 @@ const useMonthlyView = () => {
     openingPrayerLinked,
     closingPrayerLinked,
     showDoublePerson,
+
+    // Availability helper used by WeekBadge to guard autofill
+    isWeekAvailable: (weekOf: string) =>
+      sources.some((s) => s.weekOf === weekOf),
 
     // Selected Month & Week Information
     monthName,

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -1,6 +1,6 @@
 import { AssignmentCode } from '@definition/assignment';
 import { Week } from '@definition/week_type';
-import { weeksInMonth, addDays } from '@utils/date';
+import { addDays } from '@utils/date';
 import useAppTranslation from '@hooks/useAppTranslation';
 import {
   sourcesCheckAYFExplainBeliefsAssignment,
@@ -18,7 +18,7 @@ import {
   userDataViewState,
 } from '@states/settings';
 import { sourcesState } from '@states/sources';
-import { SetStateAction, useCallback, useEffect, useMemo, useState } from 'react';
+import { SetStateAction, useEffect, useMemo, useState } from 'react';
 import { useAtomValue } from 'jotai';
 
 const useMonthlyView = () => {
@@ -38,20 +38,10 @@ const useMonthlyView = () => {
     midweekMeetingClosingPrayerLinkedState
   );
 
-  const getWeeksByMonthAndYear = useCallback(
-    (year: number, month: number) => {
-      const monthStr = `${year}/${String(month + 1).padStart(2, '0')}`;
-      return weeksInMonth(monthStr);
-    },
-    []
-  );
-
   const currentYear = new Date().getFullYear().toString();
 
   const [selectedMonth, setSelectedMonth] = useState(new Date().getMonth());
-  const [selectedWeeks, setSelectedWeeks] = useState(
-    getWeeksByMonthAndYear(parseInt(currentYear), selectedMonth)
-  );
+  const [selectedWeeks, setSelectedWeeks] = useState<string[]>([]);
 
   const [weeksTypes, setWeeksTypes] = useState(
     Array(selectedWeeks.length).fill(Week.NORMAL)
@@ -206,27 +196,21 @@ const useMonthlyView = () => {
     });
   };
 
-  // Clamp selectedMonth to an available month when the selection has no data.
-  // Jumps to the highest available month index.
+  // Clamp selectedMonth to an available month when the current selection has no data.
+  // This prevents rendering an empty month and jumps to the closest available month.
   useEffect(() => {
     if (availableMonthIndices.size > 0 && !availableMonthIndices.has(selectedMonth)) {
-      const lastAvailable = Math.max(...Array.from(availableMonthIndices));
-      setSelectedMonth(lastAvailable);
+      setSelectedMonth(Math.max(...Array.from(availableMonthIndices)));
     }
   }, [availableMonthIndices, selectedMonth]);
 
   useEffect(() => {
-    // Use the actual meeting date (weekOf + congregation weekday) to group weeks
-    // by month — identical to schedulesGetMeetingDate logic used in the weekly view.
-    // weekOf is always Monday; the real meeting date may fall in the next month
-    // (e.g. weekOf=2026/08/31 + Thursday=4 → Sept 3 → month index 8 = September).
     const monthWeeks = sources
       .filter((s) => {
         if (!s.midweek_meeting?.week_date_locale?.[lang]?.length) return false;
         const meetingDate = addDays(s.weekOf, meetingWeekday);
-        const meetingYear = meetingDate.getFullYear().toString();
         return (
-          meetingYear === currentYear &&
+          meetingDate.getFullYear().toString() === currentYear &&
           meetingDate.getMonth() === selectedMonth
         );
       })
@@ -234,8 +218,6 @@ const useMonthlyView = () => {
       .sort();
     setSelectedWeeks(monthWeeks);
   }, [currentYear, selectedMonth, sources, lang, meetingWeekday]);
-
-
 
   // Reset all parallel state arrays when the selected month changes and
   // selectedWeeks grows or shrinks. Without this, out-of-bounds indices

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -111,13 +111,17 @@ const useMonthlyView = () => {
   const [addCustomModalWindowWeek, setAddCustomModalWindowWeek] =
     useState(null);
 
-  // Derive which month indices (0-11) have at least one available week.
-  // Used to hide months with no source data from the dropdown.
+  // Derive which month indices (0-11) have at least one available week
+  // in the CURRENT year. Used to hide months with no source data from the dropdown.
   const availableMonthIndices = useMemo(() => {
     const set = new Set<number>();
-    sources.forEach((s) => set.add(new Date(s.weekOf).getMonth()));
+    sources.forEach((s) => {
+      if (s.weekOf.startsWith(currentYear)) {
+        set.add(new Date(s.weekOf).getMonth());
+      }
+    });
     return set;
-  }, [sources]);
+  }, [sources, currentYear]);
 
   const thisYearMonths = monthNames;
 

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -192,6 +192,32 @@ const useMonthlyView = () => {
     );
   }, [currentYear, getWeeksByMonthAndYear, selectedMonth]);
 
+  // Reset all parallel state arrays when the selected month changes and
+  // selectedWeeks grows or shrinks. Without this, out-of-bounds indices
+  // cause EmptyAssignment to render instead of PersonSelector for the
+  // extra/missing weeks (the stale-array-size bug).
+  useEffect(() => {
+    const len = selectedWeeks.length;
+    setWeeksTypes(Array(len).fill(Week.NORMAL));
+    setAyfCount(Array(len).fill(1));
+    setAyfParts1(Array(len).fill(null));
+    setAyfParts2(Array(len).fill(null));
+    setAyfParts3(Array(len).fill(null));
+    setAyfParts4(Array(len).fill(null));
+    setIsTalkAYFParts1(Array(len).fill(false));
+    setIsTalkAYFParts2(Array(len).fill(false));
+    setIsTalkAYFParts3(Array(len).fill(false));
+    setIsTalkAYFParts4(Array(len).fill(false));
+    setLcCount(Array(len).fill(1));
+    setCustomPartEnabled(Array(len).fill(true));
+    setHasCustomPart(Array(len).fill(false));
+    setLcNoAssignParts1(Array(len).fill(false));
+    setLcNoAssignParts2(Array(len).fill(false));
+    setLcNoAssignParts3(Array(len).fill(false));
+    setIsOverwriteLCParts1(Array(len).fill(false));
+    setIsOverwriteLCParts2(Array(len).fill(false));
+  }, [selectedWeeks]);
+
   useEffect(() => {
     selectedWeeks.forEach((value, index) => {
       const schedule = schedules.find((record) => record.weekOf === value);

--- a/src/features/meetings/monthly_view/useMonthlyView.tsx
+++ b/src/features/meetings/monthly_view/useMonthlyView.tsx
@@ -1,5 +1,6 @@
 import { AssignmentCode } from '@definition/assignment';
 import { Week } from '@definition/week_type';
+import { weeksInMonth } from '@utils/date';
 import useAppTranslation from '@hooks/useAppTranslation';
 import {
   sourcesCheckAYFExplainBeliefsAssignment,
@@ -38,18 +39,10 @@ const useMonthlyView = () => {
 
   const getWeeksByMonthAndYear = useCallback(
     (year: number, month: number) => {
-      let weeks = [];
       const monthStr = `${year}/${String(month + 1).padStart(2, '0')}`;
-      sourcesFormatted.forEach((srcYear) => {
-        if (srcYear.value == year) {
-          weeks = srcYear.months.find(
-            (formattedMonth) => formattedMonth.value === monthStr
-          )?.weeks || [];
-        }
-      });
-      return weeks;
+      return weeksInMonth(monthStr);
     },
-    [sourcesFormatted]
+    []
   );
 
   const currentYear = new Date().getFullYear().toString();

--- a/src/features/meetings/monthly_view/week_badge/index.tsx
+++ b/src/features/meetings/monthly_view/week_badge/index.tsx
@@ -1,8 +1,35 @@
+import { useState } from 'react';
 import Typography from '@components/typography';
-import { Box } from '@mui/material';
+import { Box, IconButton } from '@mui/material';
 import { WeekBadgeType } from './index.types';
+import { IconGenerate } from '@components/icons';
+import IconLoading from '@components/icon_loading';
+import { displaySnackNotification } from '@services/states/app';
+import { getMessageByCode } from '@services/i18n/translation';
+import { schedulesStartAutofill } from '@services/app/autofill';
 
 const WeekBadge = (props: WeekBadgeType) => {
+  const [isProcessing, setIsProcessing] = useState(false);
+
+  const handleAutofill = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (!props.week) return;
+    
+    try {
+      setIsProcessing(true);
+      await schedulesStartAutofill(props.week, props.week, 'midweek');
+      setIsProcessing(false);
+    } catch (error) {
+      console.error(error);
+      setIsProcessing(false);
+      displaySnackNotification({
+        header: getMessageByCode('error_app_generic-title'),
+        message: getMessageByCode((error as Error).message),
+        severity: 'error',
+      });
+    }
+  };
+
   return (
     <Box
       sx={{
@@ -15,11 +42,29 @@ const WeekBadge = (props: WeekBadgeType) => {
         justifyContent: 'center',
         backgroundColor: 'var(--accent-150)',
         borderRadius: 'var(--radius-s)',
+        position: 'relative',
       }}
     >
       <Typography color={'var(--accent-dark)'} className="h4">
         {props.text}
       </Typography>
+      {props.week && (
+        <IconButton
+          onClick={handleAutofill}
+          disabled={isProcessing}
+          sx={{
+            padding: '4px',
+            position: 'absolute',
+            right: '4px',
+          }}
+        >
+          {isProcessing ? (
+            <IconLoading width={16} height={16} color="var(--accent-dark)" />
+          ) : (
+            <IconGenerate color="var(--accent-dark)" />
+          )}
+        </IconButton>
+      )}
     </Box>
   );
 };

--- a/src/features/meetings/monthly_view/week_badge/index.tsx
+++ b/src/features/meetings/monthly_view/week_badge/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, MouseEvent } from 'react';
 import Typography from '@components/typography';
 import { Box, IconButton } from '@mui/material';
 import { WeekBadgeType } from './index.types';
@@ -7,14 +7,32 @@ import IconLoading from '@components/icon_loading';
 import { displaySnackNotification } from '@services/states/app';
 import { getMessageByCode } from '@services/i18n/translation';
 import { schedulesStartAutofill } from '@services/app/autofill';
+import { useAppTranslation } from '@hooks/index';
 
 const WeekBadge = (props: WeekBadgeType) => {
   const [isProcessing, setIsProcessing] = useState(false);
+  const { t } = useAppTranslation();
 
-  const handleAutofill = async (e: React.MouseEvent) => {
+  const handleAutofill = async (e: MouseEvent) => {
     e.stopPropagation();
     if (!props.week) return;
-    
+
+    // Guard: show informative snackbar if the week's source data isn't
+    // available on JW.ORG yet instead of silently no-oping.
+    if (props.isWeekAvailable === false) {
+      displaySnackNotification({
+        header: t('tr_meetingContentPending', {
+          defaultValue: 'Meeting content pending',
+        }),
+        message: t('tr_meetingContentPendingDesc', {
+          defaultValue:
+            "This week's meeting programme hasn't been released on JW.ORG yet. Try again once it's available.",
+        }),
+        severity: 'success',
+      });
+      return;
+    }
+
     try {
       setIsProcessing(true);
       await schedulesStartAutofill(props.week, props.week, 'midweek');

--- a/src/features/meetings/monthly_view/week_badge/index.tsx
+++ b/src/features/meetings/monthly_view/week_badge/index.tsx
@@ -7,31 +7,13 @@ import IconLoading from '@components/icon_loading';
 import { displaySnackNotification } from '@services/states/app';
 import { getMessageByCode } from '@services/i18n/translation';
 import { schedulesStartAutofill } from '@services/app/autofill';
-import { useAppTranslation } from '@hooks/index';
 
 const WeekBadge = (props: WeekBadgeType) => {
   const [isProcessing, setIsProcessing] = useState(false);
-  const { t } = useAppTranslation();
 
   const handleAutofill = async (e: MouseEvent) => {
     e.stopPropagation();
     if (!props.week) return;
-
-    // Guard: show informative snackbar if the week's source data isn't
-    // available on JW.ORG yet instead of silently no-oping.
-    if (props.isWeekAvailable === false) {
-      displaySnackNotification({
-        header: t('tr_meetingContentPending', {
-          defaultValue: 'Meeting content pending',
-        }),
-        message: t('tr_meetingContentPendingDesc', {
-          defaultValue:
-            "This week's meeting programme hasn't been released on JW.ORG yet. Try again once it's available.",
-        }),
-        severity: 'success',
-      });
-      return;
-    }
 
     try {
       setIsProcessing(true);

--- a/src/features/meetings/monthly_view/week_badge/index.types.tsx
+++ b/src/features/meetings/monthly_view/week_badge/index.types.tsx
@@ -1,3 +1,4 @@
 export type WeekBadgeType = {
   text: string;
+  week?: string;
 };

--- a/src/features/meetings/monthly_view/week_badge/index.types.tsx
+++ b/src/features/meetings/monthly_view/week_badge/index.types.tsx
@@ -1,4 +1,6 @@
 export type WeekBadgeType = {
   text: string;
   week?: string;
+  /** Whether source data for this week is available on JW.ORG yet. */
+  isWeekAvailable?: boolean;
 };

--- a/src/features/meetings/monthly_view/week_badge/index.types.tsx
+++ b/src/features/meetings/monthly_view/week_badge/index.types.tsx
@@ -1,6 +1,4 @@
 export type WeekBadgeType = {
   text: string;
   week?: string;
-  /** Whether source data for this week is available on JW.ORG yet. */
-  isWeekAvailable?: boolean;
 };

--- a/src/features/meetings/monthly_view/week_hoverbox/index.tsx
+++ b/src/features/meetings/monthly_view/week_hoverbox/index.tsx
@@ -20,7 +20,6 @@ const WeekHoverBox = (props: WeekHoverBoxType) => {
       sx={{
         flex: 1,
         minWidth: 0,
-        overflow: 'hidden',
         ...props.sx,
       }}
     >

--- a/src/features/meetings/monthly_view/week_hoverbox/index.tsx
+++ b/src/features/meetings/monthly_view/week_hoverbox/index.tsx
@@ -4,34 +4,9 @@ import MeetingPart from '@features/meetings/meeting_part';
 import Tooltip from '@components/tooltip';
 import { useAtomValue } from 'jotai';
 import { userDataViewState } from '@states/settings';
-import { sourcesState } from '@states/sources';
-import Typography from '@components/typography';
-import { useAppTranslation } from '@hooks/index';
 
 const WeekHoverBox = (props: WeekHoverBoxType) => {
-  const { t } = useAppTranslation();
   const dataView = useAtomValue(userDataViewState);
-  const sources = useAtomValue(sourcesState);
-
-  // A week is "available" if a source record exists for it
-  const isWeekAvailable =
-    !props.week || sources.some((s) => s.weekOf === props.week);
-
-  const tooltipTitle = isWeekAvailable ? (
-    <MeetingPart
-      week={props.week}
-      type={props.type}
-      color={'var(--black)'}
-      dataView={dataView}
-    />
-  ) : (
-    <Typography className="body-small-regular" color="var(--grey-400)">
-      {t('tr_meetingContentPending', {
-        defaultValue:
-          "Content pending — this week's material isn't available on JW.ORG yet",
-      })}
-    </Typography>
-  );
 
   return (
     <Tooltip
@@ -57,7 +32,14 @@ const WeekHoverBox = (props: WeekHoverBoxType) => {
         },
         popper: { style: { zIndex: 2 } },
       }}
-      title={tooltipTitle}
+      title={
+        <MeetingPart
+          week={props.week}
+          type={props.type}
+          color={'var(--black)'}
+          dataView={dataView}
+        />
+      }
     >
       {props.children as ReactElement}
     </Tooltip>

--- a/src/features/meetings/monthly_view/week_hoverbox/index.tsx
+++ b/src/features/meetings/monthly_view/week_hoverbox/index.tsx
@@ -2,47 +2,57 @@ import { ReactElement } from 'react';
 import { WeekHoverBoxType } from './index.types';
 import MeetingPart from '@features/meetings/meeting_part';
 import Tooltip from '@components/tooltip';
+import { Box } from '@mui/material';
 import { useAtomValue } from 'jotai';
 import { userDataViewState } from '@states/settings';
 
+/**
+ * Wraps a cell in the monthly view.
+ * The outer Box is the actual flex item (flex:1, minWidth:0) that participates
+ * in StyledMonthlyViewRow layout and caps column width.
+ * The MUI Tooltip is inside so the hover area matches the column.
+ */
 const WeekHoverBox = (props: WeekHoverBoxType) => {
   const dataView = useAtomValue(userDataViewState);
 
   return (
-    <Tooltip
+    <Box
       sx={{
-        flex: '1',
-        // Prevent this flex child from growing beyond its share of the row
+        flex: 1,
         minWidth: 0,
         ...props.sx,
       }}
-      placement="bottom-start"
-      slotProps={{
-        tooltip: {
-          sx: {
-            padding: '16px',
-            borderRadius: 'var(--radius-m)',
-            backgroundColor: 'var(--white)',
-            border: '1px solid var(--accent-200)',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: '8px',
-            maxWidth: '339px',
-          },
-        },
-        popper: { style: { zIndex: 2 } },
-      }}
-      title={
-        <MeetingPart
-          week={props.week}
-          type={props.type}
-          color={'var(--black)'}
-          dataView={dataView}
-        />
-      }
     >
-      {props.children as ReactElement}
-    </Tooltip>
+      <Tooltip
+        sx={{ display: 'block' }}
+        placement="bottom-start"
+        slotProps={{
+          tooltip: {
+            sx: {
+              padding: '16px',
+              borderRadius: 'var(--radius-m)',
+              backgroundColor: 'var(--white)',
+              border: '1px solid var(--accent-200)',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: '8px',
+              maxWidth: '339px',
+            },
+          },
+          popper: { style: { zIndex: 2 } },
+        }}
+        title={
+          <MeetingPart
+            week={props.week}
+            type={props.type}
+            color={'var(--black)'}
+            dataView={dataView}
+          />
+        }
+      >
+        {props.children as ReactElement}
+      </Tooltip>
+    </Box>
   );
 };
 

--- a/src/features/meetings/monthly_view/week_hoverbox/index.tsx
+++ b/src/features/meetings/monthly_view/week_hoverbox/index.tsx
@@ -20,6 +20,7 @@ const WeekHoverBox = (props: WeekHoverBoxType) => {
       sx={{
         flex: 1,
         minWidth: 0,
+        overflow: 'hidden',
         ...props.sx,
       }}
     >

--- a/src/features/meetings/monthly_view/week_hoverbox/index.tsx
+++ b/src/features/meetings/monthly_view/week_hoverbox/index.tsx
@@ -2,12 +2,43 @@ import { ReactElement } from 'react';
 import { WeekHoverBoxType } from './index.types';
 import MeetingPart from '@features/meetings/meeting_part';
 import Tooltip from '@components/tooltip';
+import { useAtomValue } from 'jotai';
+import { userDataViewState } from '@states/settings';
+import { sourcesState } from '@states/sources';
+import Typography from '@components/typography';
+import { useAppTranslation } from '@hooks/index';
 
 const WeekHoverBox = (props: WeekHoverBoxType) => {
+  const { t } = useAppTranslation();
+  const dataView = useAtomValue(userDataViewState);
+  const sources = useAtomValue(sourcesState);
+
+  // A week is "available" if a source record exists for it
+  const isWeekAvailable =
+    !props.week || sources.some((s) => s.weekOf === props.week);
+
+  const tooltipTitle = isWeekAvailable ? (
+    <MeetingPart
+      week={props.week}
+      type={props.type}
+      color={'var(--black)'}
+      dataView={dataView}
+    />
+  ) : (
+    <Typography className="body-small-regular" color="var(--grey-400)">
+      {t('tr_meetingContentPending', {
+        defaultValue:
+          "Content pending — this week's material isn't available on JW.ORG yet",
+      })}
+    </Typography>
+  );
+
   return (
     <Tooltip
       sx={{
         flex: '1',
+        // Prevent this flex child from growing beyond its share of the row
+        minWidth: 0,
         ...props.sx,
       }}
       placement="bottom-start"
@@ -26,13 +57,7 @@ const WeekHoverBox = (props: WeekHoverBoxType) => {
         },
         popper: { style: { zIndex: 2 } },
       }}
-      title={
-        <MeetingPart
-          week={props.week}
-          type={props.type}
-          color={'var(--black)'}
-        />
-      }
+      title={tooltipTitle}
     >
       {props.children as ReactElement}
     </Tooltip>

--- a/src/features/meetings/person_selector/index.tsx
+++ b/src/features/meetings/person_selector/index.tsx
@@ -24,6 +24,9 @@ const PersonSelector = (props: PersonSelectorType) => {
     <Box
       sx={{
         flex: flexPersonSelector ? 1 : null,
+        // Prevent helper text from blowing out the column width in monthly view
+        overflow: 'hidden',
+        minWidth: 0,
         ...props.selectorBoxSx,
       }}
     >

--- a/src/features/meetings/person_selector/index.tsx
+++ b/src/features/meetings/person_selector/index.tsx
@@ -24,8 +24,7 @@ const PersonSelector = (props: PersonSelectorType) => {
     <Box
       sx={{
         flex: flexPersonSelector ? 1 : null,
-        // Prevent helper text from blowing out the column width in monthly view
-        overflow: 'hidden',
+        // minWidth:0 prevents this flex child from growing beyond its column share
         minWidth: 0,
         ...props.selectorBoxSx,
       }}

--- a/src/features/meetings/person_selector/index.tsx
+++ b/src/features/meetings/person_selector/index.tsx
@@ -24,8 +24,6 @@ const PersonSelector = (props: PersonSelectorType) => {
     <Box
       sx={{
         flex: flexPersonSelector ? 1 : null,
-        // minWidth:0 prevents this flex child from growing beyond its column share
-        minWidth: 0,
         ...props.selectorBoxSx,
       }}
     >

--- a/src/layouts/navbar/index.tsx
+++ b/src/layouts/navbar/index.tsx
@@ -10,6 +10,13 @@ import {
   useTheme,
 } from '@mui/material';
 import {
+  Children,
+  ReactElement,
+  cloneElement,
+  isValidElement,
+  useMemo,
+} from 'react';
+import {
   IconAccount,
   IconDonate,
   IconHelp,
@@ -88,6 +95,47 @@ const NavBar = ({ isSupported }: NavBarType) => {
     navBarOptions,
     handleQuickSettings,
   } = useNavbar();
+
+  const navBarButtons = useMemo(() => {
+    if (!navBarOptions.buttons) return null;
+
+    const buttonsEl = navBarOptions.buttons as ReactElement<any>;
+    const children = Children.toArray(
+      buttonsEl.props?.children || navBarOptions.buttons
+    );
+
+    if (children.length === 0) return navBarOptions.buttons;
+
+    let lastIndex = -1;
+    for (let i = children.length - 1; i >= 0; i--) {
+      if (isValidElement(children[i])) {
+        lastIndex = i;
+        break;
+      }
+    }
+
+    if (lastIndex === -1) return navBarOptions.buttons;
+
+    const newChildren = children.map((child, index) => {
+      if (index === lastIndex && isValidElement(child)) {
+        const childEl = child as ReactElement<any>;
+        const { color } = childEl.props;
+        const isRed = color === 'red';
+        const isYellow = color === 'yellow';
+
+        if (!isRed && !isYellow) {
+          return cloneElement(childEl, { main: true });
+        }
+      }
+      return child;
+    });
+
+    if (buttonsEl.props?.children) {
+      return cloneElement(buttonsEl, undefined, newChildren);
+    }
+
+    return <>{newChildren}</>;
+  }, [navBarOptions.buttons]);
 
   return (
     <>
@@ -533,7 +581,7 @@ const NavBar = ({ isSupported }: NavBarType) => {
                       borderRadius: 'var(--radius-xl)',
                     }}
                   >
-                    {navBarOptions.buttons}
+                    {navBarButtons}
                   </Box>
                 )}
               </>
@@ -541,8 +589,8 @@ const NavBar = ({ isSupported }: NavBarType) => {
           </Container>
         </Toolbar>
       </AppBar>
-      {navBarOptions.buttons && !tablet688Up && (
-        <BottomMenu buttons={navBarOptions.buttons} />
+      {navBarButtons && !tablet688Up && (
+        <BottomMenu buttons={navBarButtons} />
       )}
     </>
   );

--- a/src/layouts/navbar/index.tsx
+++ b/src/layouts/navbar/index.tsx
@@ -12,6 +12,7 @@ import {
 import {
   Children,
   ReactElement,
+  ReactNode,
   cloneElement,
   isValidElement,
   useMemo,
@@ -99,7 +100,9 @@ const NavBar = ({ isSupported }: NavBarType) => {
   const navBarButtons = useMemo(() => {
     if (!navBarOptions.buttons) return null;
 
-    const buttonsEl = navBarOptions.buttons as ReactElement<any>;
+    const buttonsEl = navBarOptions.buttons as ReactElement<{
+      children?: ReactNode;
+    }>;
     const children = Children.toArray(
       buttonsEl.props?.children || navBarOptions.buttons
     );
@@ -118,13 +121,16 @@ const NavBar = ({ isSupported }: NavBarType) => {
 
     const newChildren = children.map((child, index) => {
       if (index === lastIndex && isValidElement(child)) {
-        const childEl = child as ReactElement<any>;
+        const childEl = child as ReactElement<{
+          color?: string;
+          variant?: string;
+        }>;
         const { color } = childEl.props;
         const isRed = color === 'red';
         const isYellow = color === 'yellow';
 
         if (!isRed && !isYellow) {
-          return cloneElement(childEl, { main: true });
+          return cloneElement(childEl, { variant: 'main' });
         }
       }
       return child;

--- a/src/services/app/autofill.ts
+++ b/src/services/app/autofill.ts
@@ -1115,6 +1115,10 @@ export const schedulesStartAutofill = async (
       return isValid;
     });
 
+    // If no schedule records matched the requested week(s), bail out with a
+    // user-visible error rather than silently doing nothing.
+    if (weeksList.length === 0) return;
+
     if (meeting === 'midweek') {
       await handleAutofillMidweek(weeksList);
     }

--- a/src/services/app/autofill.ts
+++ b/src/services/app/autofill.ts
@@ -55,7 +55,7 @@ const handleGetWeekType = (schedule: SchedWeekType) => {
   const dataView = store.get(userDataViewState);
 
   return (
-    schedule.midweek_meeting.week_type.find(
+    schedule?.midweek_meeting?.week_type?.find(
       (record) => record.type === dataView
     )?.value ?? Week.NORMAL
   );
@@ -83,7 +83,7 @@ const handleMMAssignChairman = (
 
     // Main Hall
     main =
-      schedule.midweek_meeting.chairman.main_hall.find(
+      schedule?.midweek_meeting?.chairman?.main_hall?.find(
         (record) => record.type === dataView
       )?.value ?? '';
 
@@ -105,7 +105,7 @@ const handleMMAssignChairman = (
     }
 
     const languageWeekType =
-      schedule.midweek_meeting.week_type.find(
+      schedule?.midweek_meeting?.week_type?.find(
         (record) => record.type !== 'main'
       )?.value ?? Week.NORMAL;
 
@@ -116,7 +116,7 @@ const handleMMAssignChairman = (
 
     // Aux Class
     if (assignAux && !mmDefaultAuxCounselorEnabled) {
-      main = schedule.midweek_meeting.chairman.aux_class_1.value;
+      main = schedule?.midweek_meeting?.chairman?.aux_class_1?.value ?? '';
 
       if (weekType === Week.NORMAL && main.length === 0) {
         selected = schedulesSelectRandomPerson({
@@ -159,9 +159,9 @@ const handleMMAssignCBSConductor = (
     let assignPart = true;
 
     const mainWeekType =
-      schedule.midweek_meeting.week_type.find(
+      schedule?.midweek_meeting?.week_type?.find(
         (record) => record.type === 'main'
-      ).value || Week.NORMAL;
+      )?.value || Week.NORMAL;
 
     if (dataView !== 'main' && mainWeekType === Week.CO_VISIT) {
       assignPart = false;
@@ -170,7 +170,7 @@ const handleMMAssignCBSConductor = (
     if (!assignPart) continue;
 
     main =
-      schedule.midweek_meeting.lc_cbs.conductor.find(
+      schedule?.midweek_meeting?.lc_cbs?.conductor?.find(
         (record) => record.type === dataView
       )?.value || '';
 
@@ -203,8 +203,9 @@ const handleMMAssignTGWTalk = (
   let selected: PersonType;
 
   main =
-    schedule.midweek_meeting.tgw_talk.find((record) => record.type === dataView)
-      ?.value || '';
+    schedule?.midweek_meeting?.tgw_talk?.find(
+      (record) => record.type === dataView
+    )?.value || '';
 
   if (main.length === 0) {
     selected = schedulesSelectRandomPerson({
@@ -233,8 +234,9 @@ const handleMMAssignTGWGems = (
   let selected: PersonType;
 
   main =
-    schedule.midweek_meeting.tgw_gems.find((record) => record.type === dataView)
-      ?.value ?? '';
+    schedule?.midweek_meeting?.tgw_gems?.find(
+      (record) => record.type === dataView
+    )?.value ?? '';
 
   if (main.length === 0) {
     selected = schedulesSelectRandomPerson({
@@ -266,22 +268,22 @@ const handleMMAssignLCStandard = (
   let main = '';
   let selected: PersonType;
 
-  const lcPart = source.midweek_meeting[
+  const lcPart = source?.midweek_meeting?.[
     `lc_part${part}`
   ] as LivingAsChristiansType;
 
   const titleOverride =
-    lcPart.title.override.find((record) => record.type === dataView)?.value ??
-    '';
+    lcPart?.title?.override?.find((record) => record.type === dataView)
+      ?.value ?? '';
 
-  const titleDefault = lcPart.title.default[lang] ?? '';
+  const titleDefault = lcPart?.title?.default?.[lang] ?? '';
   const title = titleOverride.length > 0 ? titleOverride : titleDefault;
 
   const descOverride =
-    lcPart.desc.override.find((record) => record.type === dataView)?.value ??
+    lcPart?.desc?.override?.find((record) => record.type === dataView)?.value ??
     '';
 
-  const descDefault = lcPart.desc.default[lang] ?? '';
+  const descDefault = lcPart?.desc?.default?.[lang] ?? '';
   const desc = descOverride.length > 0 ? descOverride : descDefault;
 
   let noAssignLC = true;
@@ -291,11 +293,11 @@ const handleMMAssignLCStandard = (
     noAssignLC = sourcesCheckLCAssignments(title, sourceLocale);
 
     if (!noAssignLC) {
-      const lcAssign = schedule.midweek_meeting[
+      const lcAssign = schedule?.midweek_meeting?.[
         `lc_part${part}`
       ] as AssignmentCongregation[];
 
-      main = lcAssign.find((record) => record.type === dataView)?.value ?? '';
+      main = lcAssign?.find((record) => record.type === dataView)?.value ?? '';
 
       isElderPart = sourcesCheckLCElderAssignment(title, desc, sourceLocale);
 
@@ -331,20 +333,20 @@ const handleMMAssignLCCustom = (
   let main = '';
   let selected: PersonType;
 
-  const lcPart3 = source.midweek_meeting.lc_part3;
+  const lcPart3 = source?.midweek_meeting?.lc_part3;
 
   const title =
-    lcPart3.title.find((record) => record.type === dataView)?.value ?? '';
+    lcPart3?.title?.find((record) => record.type === dataView)?.value ?? '';
 
   const desc =
-    lcPart3.desc.find((record) => record.type === dataView)?.value ?? '';
+    lcPart3?.desc?.find((record) => record.type === dataView)?.value ?? '';
 
   if (title.length > 0) {
     const noAssignLC = sourcesCheckLCAssignments(title, sourceLocale);
 
     if (!noAssignLC) {
       main =
-        schedule.midweek_meeting.lc_part3.find(
+        schedule?.midweek_meeting?.lc_part3?.find(
           (record) => record.type === dataView
         )?.value ?? '';
 
@@ -387,8 +389,9 @@ const handleMMAssignCBSReader = (
   let assignPart = true;
 
   const mainWeekType =
-    schedule.midweek_meeting.week_type.find((record) => record.type === 'main')
-      .value || Week.NORMAL;
+    schedule?.midweek_meeting?.week_type?.find(
+      (record) => record.type === 'main'
+    )?.value || Week.NORMAL;
 
   if (dataView !== 'main' && mainWeekType === Week.CO_VISIT) {
     assignPart = false;
@@ -396,7 +399,7 @@ const handleMMAssignCBSReader = (
 
   if (assignPart) {
     main =
-      schedule.midweek_meeting.lc_cbs.reader.find(
+      schedule?.midweek_meeting?.lc_cbs?.reader?.find(
         (record) => record.type === dataView
       )?.value ?? '';
 
@@ -429,7 +432,7 @@ const handleMMAssignPrayer = (
   let main = '';
   let selected: PersonType;
 
-  const prayer = schedule.midweek_meeting[
+  const prayer = schedule?.midweek_meeting?.[
     `${type.toLowerCase()}_prayer`
   ] as AssignmentCongregation[];
 
@@ -465,11 +468,12 @@ const handleMMAssignBibleReading = (
 
   if (classroom === '1') {
     main =
-      schedule.midweek_meeting.tgw_bible_reading.main_hall.find(
+      schedule?.midweek_meeting?.tgw_bible_reading?.main_hall?.find(
         (record) => record.type === dataView
       )?.value ?? '';
   } else {
-    main = schedule.midweek_meeting.tgw_bible_reading.aux_class_1.value;
+    main =
+      schedule?.midweek_meeting?.tgw_bible_reading?.aux_class_1?.value ?? '';
   }
 
   if (main.length === 0) {
@@ -509,8 +513,9 @@ const handleMMAssignAYFStudent = (
   const weekType = handleGetWeekType(schedule);
 
   const languageWeekType =
-    schedule.midweek_meeting.week_type.find((record) => record.type !== 'main')
-      ?.value ?? Week.NORMAL;
+    schedule?.midweek_meeting?.week_type?.find(
+      (record) => record.type !== 'main'
+    )?.value ?? Week.NORMAL;
 
   const assignAux =
     classCount === 2 &&
@@ -521,12 +526,13 @@ const handleMMAssignAYFStudent = (
     let field: AssignmentFieldType;
 
     const ayfPart: AssignmentAYFType =
-      schedule.midweek_meeting[`ayf_part${index}`];
+      schedule?.midweek_meeting?.[`ayf_part${index}`];
 
     const type: AssignmentCode =
-      source.midweek_meeting[`ayf_part${index}`].type[lang];
+      source?.midweek_meeting?.[`ayf_part${index}`]?.type?.[lang];
 
-    const ayfSrc: string = source.midweek_meeting[`ayf_part${index}`].src[lang];
+    const ayfSrc: string =
+      source?.midweek_meeting?.[`ayf_part${index}`]?.src?.[lang];
 
     const isTalk =
       type === AssignmentCode.MM_ExplainingBeliefs
@@ -550,8 +556,9 @@ const handleMMAssignAYFStudent = (
       // Main Hall
       if (validTypesMainHall.includes(type)) {
         main =
-          ayfPart.main_hall.student.find((record) => record.type === dataView)
-            ?.value || '';
+          ayfPart?.main_hall?.student?.find(
+            (record) => record.type === dataView
+          )?.value || '';
 
         if (main.length === 0) {
           field = `MM_AYFPart${index}_Student_A` as AssignmentFieldType;
@@ -577,7 +584,7 @@ const handleMMAssignAYFStudent = (
 
       // Aux class
       if (assignAux && validTypesBase.includes(type)) {
-        main = ayfPart.aux_class_1.student.value;
+        main = ayfPart?.aux_class_1?.student?.value ?? '';
 
         if (weekType === Week.NORMAL && main.length === 0) {
           field = `MM_AYFPart${index}_Student_B` as AssignmentFieldType;
@@ -619,8 +626,9 @@ const handleMMAssignAYFAssistant = (
   const weekType = handleGetWeekType(schedule);
 
   const languageWeekType =
-    schedule.midweek_meeting.week_type.find((record) => record.type !== 'main')
-      ?.value ?? Week.NORMAL;
+    schedule?.midweek_meeting?.week_type?.find(
+      (record) => record.type !== 'main'
+    )?.value ?? Week.NORMAL;
 
   const assignAux =
     classCount === 2 &&
@@ -630,10 +638,11 @@ const handleMMAssignAYFAssistant = (
   for (const index of [1, 2, 3, 4]) {
     let field: AssignmentFieldType;
     const ayfPart: AssignmentAYFType =
-      schedule.midweek_meeting[`ayf_part${index}`];
+      schedule?.midweek_meeting?.[`ayf_part${index}`];
     const type: AssignmentCode =
-      source.midweek_meeting[`ayf_part${index}`].type[lang];
-    const ayfSrc: string = source.midweek_meeting[`ayf_part${index}`].src[lang];
+      source?.midweek_meeting?.[`ayf_part${index}`]?.type?.[lang];
+    const ayfSrc: string =
+      source?.midweek_meeting?.[`ayf_part${index}`]?.src?.[lang];
     const isTalk =
       type === AssignmentCode.MM_ExplainingBeliefs
         ? sourcesCheckAYFExplainBeliefsAssignment(ayfSrc, sourceLocale)
@@ -652,12 +661,14 @@ const handleMMAssignAYFAssistant = (
         (type === AssignmentCode.MM_ExplainingBeliefs && !isTalk)
       ) {
         const mainStudent =
-          ayfPart.main_hall.student.find((record) => record.type === dataView)
-            ?.value || '';
+          ayfPart?.main_hall?.student?.find(
+            (record) => record.type === dataView
+          )?.value || '';
 
         main =
-          ayfPart.main_hall.assistant.find((record) => record.type === dataView)
-            ?.value || '';
+          ayfPart?.main_hall?.assistant?.find(
+            (record) => record.type === dataView
+          )?.value || '';
 
         if (mainStudent.length > 0 && main.length === 0) {
           field = `MM_AYFPart${index}_Assistant_A` as AssignmentFieldType;
@@ -687,9 +698,9 @@ const handleMMAssignAYFAssistant = (
         (validTypes.includes(type) ||
           (type === AssignmentCode.MM_ExplainingBeliefs && !isTalk))
       ) {
-        const mainStudent = ayfPart.aux_class_1.student.value;
+        const mainStudent = ayfPart?.aux_class_1?.student?.value ?? '';
 
-        main = ayfPart.aux_class_1.assistant.value;
+        main = ayfPart?.aux_class_1?.assistant?.value ?? '';
 
         if (
           weekType === Week.NORMAL &&
@@ -847,7 +858,7 @@ const handleWMAssignSpeaker = (
 
     if (dataView !== 'main') {
       const mainWeekType =
-        schedule.midweek_meeting.week_type.find(
+        schedule?.midweek_meeting?.week_type?.find(
           (record) => record.type === 'main'
         )?.value ?? Week.NORMAL;
 
@@ -857,7 +868,7 @@ const handleWMAssignSpeaker = (
     if (!assignPart) continue;
 
     const talkType =
-      schedule.weekend_meeting.public_talk_type.find(
+      schedule?.weekend_meeting?.public_talk_type?.find(
         (record) => record.type === dataView
       )?.value ?? 'localSpeaker';
 
@@ -865,7 +876,7 @@ const handleWMAssignSpeaker = (
 
     // #region Speaker 1
     main =
-      schedule.weekend_meeting.speaker.part_1.find(
+      schedule?.weekend_meeting?.speaker?.part_1?.find(
         (record) => record.type === dataView
       )?.value ?? '';
 
@@ -893,13 +904,13 @@ const handleWMAssignSpeaker = (
         (record) => record.person_uid === selected.person_uid
       );
 
-      const speakerSymposium = speaker1.person_data.assignments
-        .find((a) => a.type === dataView)
-        ?.values.includes(AssignmentCode.WM_SpeakerSymposium);
+      const speakerSymposium = speaker1?.person_data?.assignments
+        ?.find((a) => a.type === dataView)
+        ?.values?.includes(AssignmentCode.WM_SpeakerSymposium);
 
       if (speakerSymposium) {
         main =
-          schedule.weekend_meeting.speaker.part_2.find(
+          schedule?.weekend_meeting?.speaker?.part_2?.find(
             (record) => record.type === dataView
           )?.value ?? '';
 
@@ -936,8 +947,9 @@ const handleWMAssignChairman = (
   let selected: PersonType;
 
   main =
-    schedule.weekend_meeting.chairman.find((record) => record.type === dataView)
-      ?.value || '';
+    schedule?.weekend_meeting?.chairman?.find(
+      (record) => record.type === dataView
+    )?.value || '';
 
   if (main.length === 0) {
     selected = schedulesSelectRandomPerson({
@@ -967,7 +979,7 @@ const handleWMAssignPrayer = (
   let selected: PersonType;
 
   main =
-    schedule.weekend_meeting.opening_prayer.find(
+    schedule?.weekend_meeting?.opening_prayer?.find(
       (record) => record.type === dataView
     )?.value ?? '';
 
@@ -999,7 +1011,7 @@ const handleWMStudyReader = (
   let selected: PersonType;
 
   main =
-    schedule.weekend_meeting.wt_study.reader.find(
+    schedule?.weekend_meeting?.wt_study?.reader?.find(
       (record) => record.type === dataView
     )?.value ?? '';
 
@@ -1049,7 +1061,7 @@ const handleAutofillWeekend = async (weeksList: SchedWeekType[]) => {
 
       if (dataView !== 'main') {
         const mainWeekType =
-          schedule.midweek_meeting.week_type.find(
+          schedule?.midweek_meeting?.week_type?.find(
             (record) => record.type === 'main'
           )?.value ?? Week.NORMAL;
 
@@ -1096,23 +1108,9 @@ export const schedulesStartAutofill = async (
     if (start.length === 0 || end.length === 0) return;
 
     const schedules = store.get(schedulesState);
-    const sources = store.get(sourcesState);
-    const lang = store.get(JWLangState);
 
     const weeksList = schedules.filter((schedule) => {
       const isValid = schedule.weekOf >= start && schedule.weekOf <= end;
-
-      if (!isValid) return false;
-
-      const source = sources.find((src) => src.weekOf === schedule.weekOf)!;
-
-      if (meeting === 'midweek') {
-        if (!source.midweek_meeting.week_date_locale[lang]) return false;
-      }
-
-      if (meeting === 'weekend') {
-        if (!source.weekend_meeting.w_study[lang]) return false;
-      }
 
       return isValid;
     });


### PR DESCRIPTION
# Description

This PR refactors the Monthly View filtering and resolves several UI bugs to match the exact behavior and visual stability of the Weekly View. 

**Changes Include:**
- **Canonical Sync Filtering**: Aligned the month dropdown and weeks list to use the `midweek_meeting.week_date_locale[lang]` filter (identical to `useMidweekContainer`), ensuring only weeks with successfully published meeting materials are rendered.
- **Accurate Meeting Date Calculation**: Month grouping and column headers now calculate based on the actual meeting date (e.g. `weekOf + congregation meeting day`) rather than defaulting to Monday, fixing issues where weeks incorrectly appeared in the previous month.
- **Full Width Responsiveness**: Fixed unwrapped flex-items (Chairman, Aux Counselor, Opening/Closing Prayer) that weren't spanning the entire width when fewer columns were present. 
- **Helper Text Constraint**: Applied constraints to `.MuiFormHelperText-root` to truncate long error/warning messages with an ellipsis, preventing them from blowing out the flex grid column width.
- **Label Rendering Fix**: Removed a CSS transform hack that was clipping the label boundaries in certain layout cases.
- **Code Cleanup**: Removed unused imports (`weeksInMonth`, `useCallback`) and simplified initial state logic in `useMonthlyView`.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream modules
